### PR TITLE
Support for multiple DRV2605 haptic motor drivers

### DIFF
--- a/drv2605.cpp
+++ b/drv2605.cpp
@@ -28,162 +28,299 @@
  */
 
 #include "drv2605.h"
+
+#if DRV2605_SUPPORT_WIRE_I2C
 #include <Wire.h>
+#endif
+
+#if DRV2605_SUPPORT_SOFT_I2C
+#include <SoftI2CMaster.h>
+#endif
+
 #include <Arduino.h>
 
-void DRV2605::init(void)
+int DRV2605::init(bool bSoftI2C = false, bool bVerbose = true)
 {
-    Wire.begin();
-    drv2605ReadID();
+	this->bSoftI2C = bSoftI2C;
+	this->bVerbose = bVerbose;
+	
+	/* Check desired I2C mode with supported I2C modes and initialize i2C */
+#if DRV2605_SUPPORT_WIRE_I2C
+	if (!bSoftI2C)
+	{
+		Wire.begin();
+	}
+#else
+	if (!bSoftI2C) return -1; /* Wire I2C desired, but not supported */
+#endif /* DRV2605_SUPPORT_WIRE_I2C */
 
-    drv2605Write(MODE_Reg, 0x40);    //enter standby mode
-    delayMicroseconds(250);
-    
-    drv2605Write(RATED_VOLTAGE_Reg, 0x50);      //Set Rate Voltage
-    drv2605Write(OD_CLAMP_Reg, 0x89);       //Set overdrive Voltage
-    drv2605Write(FB_CON_Reg, 0xB6);
-    drv2605Write(CONTRL1_Reg, 0x13);
-    drv2605Write(CONTRL2_Reg, 0xF5);
-    drv2605Write(CONTRL3_Reg, 0x80);
-    drv2605Write(LIB_SEL_Reg, 0x06);        //select the LRA Lib
-    
-    drv2605Write(MODE_Reg, 0x00);     //Put DRV2605 device in active mode
+#if DRV2605_SUPPORT_SOFT_I2C
+	if (bSoftI2C)
+	{
+		if (!i2c_init()) return -1; /* i2c_init failed */
+	}
+#else
+	if (bSoftI2C) return -1;  /* Soft I2C desired, but not supported */
+#endif /* DRV2605_SUPPORT_SOFT_I2C */
+
+	if (bVerbose)
+		/* Read the DRV2605 Device ID */
+	{
+		unsigned char ucDeviceID;
+		if (drv2605Read(0x00, (char*)&ucDeviceID) == 0)
+		{
+			Serial.print("DRV2605 ID: 0x");
+			Serial.println(ucDeviceID, HEX);
+		}
+		else
+		{
+			Serial.println("Reading DRV2605 ID failed!");
+		}
+	}
+
+	/* Enter standby mode */
+	if (drv2605Write(MODE_Reg, 0x40) != 0) return -1;
+	delayMicroseconds(250);
+
+	/* Set rate voltage */
+	if (drv2605Write(RATED_VOLTAGE_Reg, 0x50) != 0) return -1;
+
+	/* Set overdrive voltage */
+	if (drv2605Write(OD_CLAMP_Reg, 0x89) != 0) return -1;
+	
+	/* Setup feedback control and control registers */
+	if (drv2605Write(FB_CON_Reg, 0xB6) != 0) return -1;
+	if (drv2605Write(CONTRL1_Reg, 0x13) != 0) return -1;
+	if (drv2605Write(CONTRL2_Reg, 0xF5) != 0) return -1;
+	if (drv2605Write(CONTRL3_Reg, 0x80) != 0) return -1;
+	
+	/* Select the LRA Library */
+	if (drv2605Write(LIB_SEL_Reg, 0x06) != 0) return -1;
+
+	/* Put the DRV2605 device in active mode */
+	if (drv2605Write(MODE_Reg, 0x00) != 0) return -1;
 }
 
-// Read 1 byte from the BMP085 at 'address'
-// Return: the read byte;
-char DRV2605::drv2605Read(unsigned char address)
+/* Try to read 1 byte from the DRV2605 register at 'regAddress'.
+ * The read value is stored in *pcValue
+ * Returns 0 on success or -1 on failure.
+ */
+int DRV2605::drv2605Read(unsigned char ucRegAddress, char* pcValue)
 {
-    //Wire.begin();
-    unsigned char data;
-    Wire.beginTransmission(DRV2605_ADDRESS);
-    Wire.write(address);
-    Wire.endTransmission();
+#if DRV2605_SUPPORT_WIRE_I2C
+	if (!bSoftI2C)
+	{
+		Wire.beginTransmission(DRV2605_ADDRESS);
+		if (Wire.write(ucRegAddress) != 1) return -1;
+		if (Wire.endTransmission(false) != 0) return -1;
 
-    Wire.requestFrom(DRV2605_ADDRESS, 1);
-    while(!Wire.available());
-    return Wire.read();
+		Wire.requestFrom(DRV2605_ADDRESS, 1);
+		
+		while(!Wire.available());
+		
+		*pcValue = Wire.read();
+		
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_WIRE_I2C */
+
+#if DRV2605_SUPPORT_SOFT_I2C
+	if (bSoftI2C)
+	{
+		/* Send the device slave address and a write bit */
+		if (!i2c_start((DRV2605_ADDRESS << 1) | I2C_WRITE)) return -1;
+
+		/* Write the register address that we want to write to */
+		if (!i2c_write(ucRegAddress)) return -1;
+
+		/* Resend start condition */
+		if (!i2c_rep_start((DRV2605_ADDRESS << 1) | I2C_READ)) return -1;
+
+		/* Read data from register and send NAK */
+		*pcValue = i2c_read(true);
+
+		/* Send stop condition */
+		i2c_stop();
+
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_SOFT_I2C */
 }
 
-// Read 2 bytes from the BMP085
-// First byte will be from 'address'
-// Second byte will be from 'address'+1
-int DRV2605::drv2605ReadInt(unsigned char address)
+/* Perform a multi byte read (2 bytes) on the DRV2605.
+ * First byte (most significant) will be from register at 'ucRegAddress'.
+ * Second byte (least significant) will be from register at 'ucRegAddress' + 1.
+ */
+int DRV2605::drv2605ReadInt(unsigned char ucRegAddress, int* piValue)
 {
-    unsigned char msb, lsb;
-    Wire.beginTransmission(DRV2605_ADDRESS);
-    Wire.write(address);
-    Wire.endTransmission();
-    Wire.requestFrom(DRV2605_ADDRESS, 2);
-    while(Wire.available()<2);
-    msb = Wire.read();
-    lsb = Wire.read();
-    return (int) msb<<8 | lsb;
+#if DRV2605_SUPPORT_WIRE_I2C
+	if (!bSoftI2C)
+	{
+		Wire.beginTransmission(DRV2605_ADDRESS);
+		if (Wire.write(ucRegAddress) != 1) return -1;
+		if (Wire.endTransmission(false) != 0) return -1;
+
+		Wire.requestFrom(DRV2605_ADDRESS, 2);
+		
+		while(Wire.available() < 2);
+		
+		*piValue = ((int)Wire.read()) << 8;
+		*piValue |= Wire.read();
+		
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_WIRE_I2C */
+
+#if DRV2605_SUPPORT_SOFT_I2C
+	if (bSoftI2C)
+	{
+		/* Send the device slave address and a write bit */
+		if (!i2c_start((DRV2605_ADDRESS << 1) | I2C_WRITE)) return -1;
+
+		/* Write the register address that we want to write to */
+		if (!i2c_write(ucRegAddress)) return -1;
+
+		/* Resend start condition */
+		if (!i2c_rep_start((DRV2605_ADDRESS << 1) | I2C_READ)) return -1;
+
+		/* Read data from register and send ACK */
+		*piValue = ((int)i2c_read(false)) << 8;
+
+		/* Read the last byte from register and send NAK */
+		*piValue |= i2c_read(true);
+		
+		/* Send stop condition */
+		i2c_stop();
+
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_SOFT_I2C */
 }
 
-void DRV2605::drv2605Write(unsigned char address, byte val)
+int DRV2605::drv2605Write(unsigned char ucRegAddress, char cValue)
 {
-    char i = 1;
-    Wire.beginTransmission(DRV2605_ADDRESS); // start transmission to device 
-    Wire.write(address);       // send register address
-    Wire.write(val);         // send value to write
-    i = Wire.endTransmission();     // end transmission
-    if(0 != i)
-    {
-        Serial.print("Transmission error!!!\n");
-    }
+#if DRV2605_SUPPORT_WIRE_I2C
+	if (!bSoftI2C)
+	{
+		Wire.beginTransmission(DRV2605_ADDRESS); // start transmission to device 
+		if (Wire.write(ucRegAddress) != 1) return -1;
+		if (Wire.write(cValue) != 1) return -1;
+		if (Wire.endTransmission() != 0) return -1;
+		
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_WIRE_I2C */
+
+#if DRV2605_SUPPORT_SOFT_I2C
+	if (bSoftI2C)
+	{
+		/* Send the device slave address and a write bit */
+		if (!i2c_start((DRV2605_ADDRESS << 1) | I2C_WRITE)) return -1;
+
+		/* Write the register address that we want to write to */
+		if (!i2c_write(ucRegAddress)) return -1;
+		
+		/* Write the data byte */
+		if (!i2c_write(cValue)) return -1;
+		
+		/* Send stop condition */
+		i2c_stop();
+		
+		return 0;
+	}
+#endif /* DRV2605_SUPPORT_SOFT_I2C */
 }
 
-void DRV2605::writeRegister(int deviceAddress, byte address, byte val)
+int DRV2605::drv2605_AutoCal(void)
 {
-    Wire.beginTransmission(deviceAddress); // start transmission to device 
-    Wire.write(address);       // send register address
-    Wire.write(val);         // send value to write
-    Wire.endTransmission();     // end transmission
-}
-int DRV2605::readRegister(int deviceAddress, byte address)
-{
-    int v;
-    Wire.beginTransmission(deviceAddress);
-    Wire.write(address); // register to read
-    Wire.endTransmission();
+    unsigned char temp = 0x00;
+    unsigned char ACalComp, ACalBEMF, BEMFGain;
 
-    Wire.requestFrom(deviceAddress, 1); // read a byte
+	/* Set rate voltage */
+	if (drv2605Write(RATED_VOLTAGE_Reg, 0x50) != 0) return -1;
 
-    while(!Wire.available()) {
-    // waiting
-    }
+	/* Set overdrive voltage */
+	if (drv2605Write(OD_CLAMP_Reg, 0x89) != 0) return -1;
+	
+	/* Setup feedback control and control registers */
+	if (drv2605Write(FB_CON_Reg, 0xB6) != 0) return -1;
+	if (drv2605Write(CONTRL1_Reg, 0x93) != 0) return -1;
+	if (drv2605Write(CONTRL2_Reg, 0xF5) != 0) return -1;
+	if (drv2605Write(CONTRL3_Reg, 0x80) != 0) return -1;
+	
+	/* Put the DRV2605 device in auto calibration mode */
+	if (drv2605Write(MODE_Reg, 0x07) != 0) return -1;
+    
+    if (drv2605Write(CONTRL4_Reg, 0x20) != 0) return -1;
+	
+	/* Begin auto calibration */
+    if (drv2605Write(GO_Reg, 0x01) != 0) return -1;
+    if (bVerbose) Serial.println("DRV2605 Auto-calibrating...");
+	
+	/* Poll the GO register until least significant bit is set */
+	while ((temp & 0x01) != 0x01)
+	{
+		if (drv2605Read(GO_Reg, (char*)&temp) != 0) return -1;
+	}
+	
+	/* Read the result of the auto calibration */
+	if (drv2605Read(STATUS_Reg, (char*)&temp) != 0) return -1;
+	if (bVerbose)
+	{
+		Serial.print("STATUS_Reg: 0x");
+		Serial.println(temp, HEX);
+	}
+	
+	/* Check auto calibration result for success or failure */
+    if ((temp & 0x08) != 0x00)
+	{
+        if (bVerbose) Serial.println("DRV2605 Auto-calibration fail");
+		return -1;
+	}
+	if (bVerbose) Serial.println("DRV2605 Auto-calibration complete");
+    
+	/* Read the compensation result of the auto calibration */
+	if (drv2605Read(A_CAL_COMP_Reg, (char*)&ACalComp) != 0) return -1;
+	if (bVerbose)
+	{
+		Serial.print("Auto-Calibration Compensation Result: 0x");
+		Serial.println(ACalComp, HEX);
+	}
 
-    v = Wire.read();
-    return v;
-}
+	/* Read the Back-EMF result of the auto calibration */
+	if (drv2605Read(A_CAL_BEMF_Reg, (char*)&ACalBEMF) != 0) return -1;
+	if (bVerbose)
+	{
+		Serial.print("Auto-Calibration Back-EMF Result: 0x");
+		Serial.println(ACalBEMF, HEX);
+	}
 
-void DRV2605::drv2605ReadID(void)
-{
-    unsigned char temp;
-    temp = drv2605Read(0);
-    Serial.print("DRV2605 ID:0x");
-    Serial.println(temp,HEX);
-}
+	/* Read the feedback control */
+	if (drv2605Read(FB_CON_Reg, (char*)&BEMFGain) != 0) return -1;
+	if (bVerbose)
+	{
+		Serial.print("Feedback Control: 0x");
+		Serial.println(BEMFGain, HEX);
 
-void DRV2605::drv2605_AutoCal(void)
-{
-    unsigned char temp;
-    unsigned char ACalComp,ACalBEMF,BEMFGain;
-
-    drv2605Write(RATED_VOLTAGE_Reg, 0x50);      //Set Rate Voltage
-    drv2605Write(OD_CLAMP_Reg, 0x89);       //Set overdrive Voltage
-    drv2605Write(FB_CON_Reg, 0xB6);
-    drv2605Write(CONTRL1_Reg, 0x93);
-    drv2605Write(CONTRL2_Reg, 0xF5);
-    drv2605Write(CONTRL3_Reg, 0x80);
-    
-    drv2605Write(MODE_Reg, 0x07);
-    
-    drv2605Write(CONTRL4_Reg, 0x20);
-    drv2605Write(GO_Reg, 0x01);    //begin to auto-cal
-    Serial.println("DRV2605 Auto-calibrating");
-    while( (drv2605Read(GO_Reg) & 0x01) != 0x01 );
-    temp = drv2605Read(STATUS_Reg);
-    Serial.print("STATUS_Reg:0x");
-    Serial.println(temp,HEX);
-    temp &= 0x08;
-    if(temp == 0)
-        Serial.println("DRV2605 Auto-calibration complete");
-    else
-        Serial.println("DRV2605 Auto-calibration fail");
-    
-    ACalComp = drv2605Read(A_CAL_COMP_Reg);
-    Serial.print("Auto-Calibration Compensation Result:0x");
-    Serial.println(ACalComp,HEX);
-    
-    ACalBEMF = drv2605Read(A_CAL_BEMF_Reg);
-    Serial.print("Auto-Calibration Back-EMF Result:0x");
-    Serial.println(ACalBEMF,HEX);
-    
-    BEMFGain = drv2605Read(FB_CON_Reg);
-    Serial.print("Feedback Control:0x");
-    Serial.println(BEMFGain,HEX);
-    BEMFGain &= 0x03;
-    Serial.print("Analog gain of the back-EMF amplifier:");
-    if(BEMFGain == 0)
-        Serial.println("5x");
-    else if(BEMFGain == 1)
-        Serial.println("10x");
-    else if(BEMFGain == 2)
-        Serial.println("20x");
-    else 
-        Serial.println("30x");
-    
+		Serial.print("Analog gain of the back-EMF amplifier:");
+		if ((BEMFGain & 0x03) == 0) Serial.println("5x");
+		else if ((BEMFGain & 0x03) == 1) Serial.println("10x");
+		else if ((BEMFGain & 0x03) == 2) Serial.println("20x");
+		else Serial.println("30x");
+	}
+	
+	return 0;
 }
 
-void DRV2605::drv2605_Play_Waveform(unsigned char effect)
+int DRV2605::drv2605_Play_Waveform(unsigned char ucEffect)
 {
-    drv2605Write(MODE_Reg, 0x00);//exit standby mode and use internal trigger
+	/* Exit standby mode and use internal trigger */
+    if (drv2605Write(MODE_Reg, 0x00) != 0) return -1;
     
-    drv2605Write(WAV_SEQ1_Reg, effect);
-    drv2605Write(WAV_SEQ2_Reg, 0x00);
+    if (drv2605Write(WAV_SEQ1_Reg, ucEffect) != 0) return -1;
+    if (drv2605Write(WAV_SEQ2_Reg, 0x00) != 0) return -1;
 
-    drv2605Write(GO_Reg, 0x01);
+    if (drv2605Write(GO_Reg, 0x01) != 0) return -1;
     
+	return 0;
 }

--- a/drv2605.h
+++ b/drv2605.h
@@ -31,8 +31,13 @@
 #define __DRV2605_H__
 
 #include <Arduino.h>
-#include <Wire.h>
 
+#define DRV2605_SUPPORT_WIRE_I2C 1
+#define DRV2605_SUPPORT_SOFT_I2C 0
+//#define SDA_PORT PORTD
+//#define SDA_PIN 3
+//#define SCL_PORT PORTD
+//#define SCL_PIN 2
 
 #define STATUS_Reg          0x00
 #define MODE_Reg            0x01
@@ -80,28 +85,16 @@
 class DRV2605
 {
 public: 
-  void init(void);
-  char drv2605Read(unsigned char address);
-  int drv2605ReadInt(unsigned char address);
-  void writeRegister(int deviceAddress, byte address, byte val);
-  int readRegister(int deviceAddress, byte address);
-  void drv2605ReadID(void);
-  void drv2605Write(unsigned char address, byte val);
-  void drv2605_AutoCal(void);
-  void drv2605_Play_Waveform(unsigned char effect);
+	int init(bool bSoftI2C, bool bVerbose);
+	int drv2605Read(unsigned char ucRegAddress, char* pcValue);
+	int drv2605ReadInt(unsigned char ucRegAddress, int* piValue);
+	int drv2605Write(unsigned char ucRegAddress, char cValue);
+	int drv2605_AutoCal(void);
+	int drv2605_Play_Waveform(unsigned char ucEffect);
 
 private:
-  int ac1;
-  int ac2;
-  int ac3;
-  unsigned int ac4;
-  unsigned int ac5;
-  unsigned int ac6;
-  int b1;
-  int b2;
-  int mb;
-  int mc;
-  int md;
+	bool bSoftI2C; /* Use software I2C on digital pins or Wire I2C on designated I2C pins */
+	bool bVerbose; /* Write diagnostic information to the serial port */
 };
 
-#endif
+#endif /*  __DRV2605_H__ */

--- a/example/drv2605/drv2605.ino
+++ b/example/drv2605/drv2605.ino
@@ -27,7 +27,13 @@
  * THE SOFTWARE.
  */
 
-#include <Wire.h>
+/* Since the Haptic Motor driver DRV2605 does not allow change of the I2C slave address,
+ * it is not possible to use multiple drivers on the same I2C bus. An alternative
+ * solution is to implement a software I2C bus on two other digital I/O pins (SCL and SDA)
+ * in conjunction with the default I2C bus.
+ * Edit drv2605.h to enable software I2C bus (requires SoftI2CMaster library) and choose
+ * two digital pins for the SCL and SDA signals of the second I2C bus.
+ */
 #include <drv2605.h>
 
 DRV2605 haptic;
@@ -35,8 +41,9 @@ DRV2605 haptic;
 void setup()
 {
     Serial.begin(9600);
-    haptic.init();
-    haptic.drv2605_AutoCal();
+    /* Software I2C = true, Verbose = true */
+    if (haptic.init(true, true) != 0) Serial.println("init failed!");
+    if (haptic.drv2605_AutoCal() != 0) Serial.println("auto calibration failed!");
     delay(2000);
 }
 


### PR DESCRIPTION
- Added support for a secondary software I2C bus (allowing use of multiple DRV2605 haptic motor drivers with the same I2C slave address).
- Diagnostic output (printed to the serial port) of the driver software can be turned on or off using the verbose argument.
- Return values of driver functions used to report success or failure.
- Removed unused functions and variables.
